### PR TITLE
BodyObj is required BodyObj.Body can be null

### DIFF
--- a/libs/deso-protocol/src/lib/post/Posts.ts
+++ b/libs/deso-protocol/src/lib/post/Posts.ts
@@ -55,8 +55,8 @@ export class Posts {
     if (!request.UpdaterPublicKeyBase58Check) {
       throw Error('UpdaterPublicKeyBase58Check is required');
     }
-    if (!request.BodyObj?.Body) {
-      throw Error('BodyObj.Body is required');
+    if (!request.BodyObj) {
+      throw Error('BodyObj is required');
     }
     if (!request.MinFeeRateNanosPerKB) {
       request.MinFeeRateNanosPerKB = 1000;


### PR DESCRIPTION
See #2 in some cases BodyObj.Body can be null. For instance when a normal repost is done or people just add and image or video without text.