### PR TITLE
Get correct postHashHex after signing transaction & iframe style fix

### DIFF
--- a/libs/deso-protocol/src/lib/identity/Identity.ts
+++ b/libs/deso-protocol/src/lib/identity/Identity.ts
@@ -150,7 +150,7 @@ export class Identity {
     frame.style.zIndex = '1000';
     frame.style.display = 'none';
     frame.style.left = '0';
-    frame.style.right = '0';
+    frame.style.top = '0';
     const root = document.getElementsByTagName('body')[0];
     if (root) {
       root.appendChild(frame);

--- a/libs/deso-protocol/src/lib/post/Posts.ts
+++ b/libs/deso-protocol/src/lib/post/Posts.ts
@@ -71,7 +71,7 @@ export class Posts {
     ).data;
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, extraData)
-      .then(() => apiResponse)
+      .then((txn) => {apiResponse.PostHashHex = txn.data.TxnHashHex; return apiResponse })
       .catch(() => {
         throw Error('something went wrong while signing');
       });


### PR DESCRIPTION
The flow of submit post returns the temp hex. The correct hex is the one used here. So that the result can be used to redirect to the post or make an NFT for instance.

The other fix is for the iframe style. In case the iframe identity **info** method detects it does not have access to the iframe local storage. Happens on Mac and iOS. In that case you need to show to iframe so a user can tap it to gain access. Without it transactions **fail**. Normally some logic needs to be added like:

1. Call info method (after initialize)
2. Check if browser supported and if has sufficient access
3. Show iframe at full width and height
4. Catch _storageGranted_ post message to hide iframe.

to check the access something like

`if(event.data.payload && event.data.payload.browserSupported){				
if(!event.data.payload.hasStorageAccess || !event.data.payload.hasLocalStorageAccess){
//set iframe display to block
`
Can be used. 
