### PR TITLE
? In case payload undefined

### DIFF
--- a/libs/deso-protocol/src/lib/identity/WindowHandler.ts
+++ b/libs/deso-protocol/src/lib/identity/WindowHandler.ts
@@ -84,7 +84,7 @@ export const handlers = async (
   }
 
   if (info.iFrameMethod === 'jwt') {
-    if (event.data.payload.jwt) {
+    if (event.data.payload?.jwt) {
       info.data.prompt?.close();
       info.data.resolve(event.data.payload.jwt);
       window.removeEventListener('message', windowHandler);


### PR DESCRIPTION
Extra check for payload. When I use the latest version in combination with SvelteKit and Vercel I get:

`Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'jwt')` 