### PR TITLE
chore(deso-protocol/utils): added helper function to get base58 key

### DIFF
--- a/libs/deso-protocol/src/lib/utils/Utils.ts
+++ b/libs/deso-protocol/src/lib/utils/Utils.ts
@@ -142,3 +142,10 @@ export const getMetaMaskMasterPublicKeyFromSignature = (
   const encodedDesoKey = bs58check.encode(desoKey);
   return encodedDesoKey;
 };
+
+export const privateKeyToDeSoPublicKey = (privateKey: ec.KeyPair): string => {
+  const prefix = PUBLIC_KEY_PREFIXES.mainnet.deso;
+  const key = privateKey.getPublic().encode('array', true);
+  const prefixAndKey = Uint8Array.from([...prefix, ...key]);
+  return bs58check.encode(prefixAndKey);
+};


### PR DESCRIPTION
helpful in scenarios where you generate a key