### PR TITLE
fix: chrome on android stuck on tap to unlock

### DIFF
--- a/libs/deso-protocol/src/lib/identity/WindowHandler.ts
+++ b/libs/deso-protocol/src/lib/identity/WindowHandler.ts
@@ -105,7 +105,10 @@ export const handlers = async (
     window.removeEventListener('derive', windowHandler);
   }
 
-  if (info.iFrameMethod === 'info' && event.data.payload) {
+  if (
+    info.iFrameMethod === 'info' &&
+    Object.keys(event.data.payload ?? {}).length > 0
+  ) {
     info.data.resolve(event.data.payload);
     window.removeEventListener('info', windowHandler);
   }


### PR DESCRIPTION
For some odd reason I haven't fully understood yet, on Google Chrome for Android, the info payload is passed twice when the page is loaded. Once it is passed with an empty payload object. The second time it is passed with the expected payload.

There was already a check for payload existence, but this fails because an empty object is "truthy." So here we just add an additional check that the payload actually has something in it.