### PR TITLE
Fix: updating deso-protocol-types version

### DIFF
--- a/libs/deso-protocol/package.json
+++ b/libs/deso-protocol/package.json
@@ -4,7 +4,7 @@
   "type": "commonjs",
   "dependencies": {
     "axios": "^0.25.0",
-    "deso-protocol-types": "0.3.2",
+    "deso-protocol-types": "0.5.0",
     "@types/bs58check": "^2.1.0",
     "tus-js-client": "^2.3.1",
     "crypto-browserify": "^3.12.0",


### PR DESCRIPTION
Seems like @jackson-dean updated the types manually.

Is it enough to update only the version of `deso-protocol-types` here?