### PR TITLE
GetLikesForPost on frontend fix

### DIFF
--- a/apps/developer-hub/src/chapters/ChapterHelper/PostsChapter.tsx
+++ b/apps/developer-hub/src/chapters/ChapterHelper/PostsChapter.tsx
@@ -281,7 +281,7 @@ export const postChapter = {
             <Page
               demo={true}
               method={{
-                methodName: `deso.posts.getDiamondedPosts(request)`,
+                methodName: `deso.posts.GetLikesForPost(request)`,
                 params: this.params,
                 method: this.method,
               }}


### PR DESCRIPTION
There was getDiamondedPosts endpoint on get likes for post api on frontend. This should fix it!!

getDiamondedPosts(request) > GetLikesForPost(request)