### PR TITLE
More access group endpoints and types and other small enhancements

### DIFF
--- a/libs/deso-protocol-types/src/lib/deso-types.ts
+++ b/libs/deso-protocol-types/src/lib/deso-types.ts
@@ -2844,6 +2844,7 @@ export interface GetExchangeRateResponse {
   USDCentsPerBitCloutExchangeRate: number;
   USDCentsPerBitCloutReserveExchangeRate: number;
   USDCentsPerDeSoCoinbase: number;
+  USDCentsPerDeSoBlockchainDotCom: number;
 }
 
 // struct2ts:types/generated/types.BlockchainDeSoTickerResponse
@@ -3372,6 +3373,15 @@ export interface GetVideoStatusResponse {
   Dimensions: { [key: string]: any };
 }
 
+export interface GetVideoDimensionsResponse {
+  Height: number;
+  Width: number;
+}
+
+export interface EnableVideoDownloadResponse {
+  Default: { [k: string]: any };
+}
+
 // struct2ts:types/generated/types.GetMessagesStatelessRequest
 export interface GetMessagesStatelessRequest {
   PublicKeyBase58Check: string;
@@ -3889,11 +3899,31 @@ export interface GetPostsStatelessRequest {
   MediaRequired: boolean;
   PostsByDESOMinutesLookback: number;
   AddGlobalFeedBool: boolean;
+  OnlyNFTs: boolean;
+  OnlyPosts: boolean;
 }
 
 // struct2ts:types/generated/types.GetPostsStatelessResponse
 export interface GetPostsStatelessResponse {
   PostsFound: PostEntryResponse[] | null;
+}
+
+export interface GetPostsHashHexListRequest {
+  PostsHashHexList: string[];
+  ReaderPublicKeyBase58Check: string;
+  OrderBy: string;
+  OnlyNFTs: boolean;
+  OnlyPosts: boolean;
+}
+
+export interface SkippedPostEntryResponse {
+  PostHashHex: string;
+  Error: string;
+}
+
+export interface GetPostsHashHexListResponse {
+  PostsFound: PostEntryResponse[];
+  PostsSkipped: SkippedPostEntryResponse[];
 }
 
 // struct2ts:types/generated/types.GetSinglePostRequest
@@ -3928,6 +3958,8 @@ export interface GetPostsForPublicKeyRequest {
   LastPostHashHex: string;
   NumToFetch: number;
   MediaRequired: boolean;
+  OnlyNFTs: boolean;
+  OnlyPosts: boolean;
 }
 
 // struct2ts:types/generated/types.GetPostsForPublicKeyResponse
@@ -5115,6 +5147,33 @@ export interface CheckPartyAccessGroupsResponse {
   IsRecipientAccessGroupKey: boolean;
 }
 
+export interface GetAccessGroupInfoRequest {
+  AccessGroupOwnerPublicKeyBase58Check: string;
+  AccessGroupKeyName: string;
+}
+
+export interface GetAccessGroupMemberRequest {
+  AccessGroupMemberPublicKeyBase58Check: string;
+  AccessGroupOwnerPublicKeyBase58Check: string;
+  AccessGroupKeyName: string;
+}
+
+export interface GetPaginatedAccessGroupMembersRequest {
+  AccessGroupOwnerPublicKeyBase58Check: string;
+  AccssGroupKeyName: string;
+  StartingAccessGroupMemberPublicKeyBase58Check: string;
+  MaxMembersToFetch: number;
+}
+
+export interface PublicKeyToProfileEntryResponseMap {
+  [k: string]: ProfileEntryResponse | null;
+}
+
+export interface GetPaginatedAccessGroupMembersResponse {
+  AccessGroupMembersBase58Check: string[];
+  PublicKeyToProfileEntryResponse: PublicKeyToProfileEntryResponseMap;
+}
+
 export interface GroupOwnerAndGroupKeyNamePair {
   GroupOwnerPublicKeyBase58Check: string;
   GroupKeyName: string;
@@ -5139,6 +5198,8 @@ export interface SendNewMessageRequest {
   RecipientAccessGroupKeyName: string;
 
   EncryptedMessageText: string;
+
+  TimestampNanosString: string;
 
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[];
@@ -5192,6 +5253,8 @@ export interface GetPaginatedMessagesForDmThreadRequest {
 
 export interface GetPaginatedMessagesForDmThreadResponse {
   ThreadMessages: NewMessageEntryResponse[];
+
+  PublicKeyToProfileEntryResponse: PublicKeyToProfileEntryResponseMap;
 }
 
 export interface GetPaginatedMessagesForGroupChatThreadRequest {
@@ -5204,6 +5267,8 @@ export interface GetPaginatedMessagesForGroupChatThreadRequest {
 
 export interface GetPaginatedMessagesForGroupChatThreadResponse {
   GroupChatMessages: NewMessageEntryResponse[];
+
+  PublicKeyToProfileEntryResponse: PublicKeyToProfileEntryResponseMap;
 }
 
 export interface GetUserMessageThreadsRequest {
@@ -5212,6 +5277,8 @@ export interface GetUserMessageThreadsRequest {
 
 export interface GetUserMessageThreadsResponse {
   MessageThreads: NewMessageEntryResponse[];
+
+  PublicKeyToProfileEntryResponse: PublicKeyToProfileEntryResponseMap;
 }
 
 export type DecryptedMessageEntryResponse = NewMessageEntryResponse & {
@@ -5219,3 +5286,13 @@ export type DecryptedMessageEntryResponse = NewMessageEntryResponse & {
   IsSender: boolean;
   error: string;
 };
+
+export interface GetSnapshotEpochMetadataResponse {
+  SnapshotBlockHeight: number;
+  CurrentEpochChecksumHex: string;
+  CurrentEpochBlockHashHex: string;
+}
+
+export interface GetStateChecksumResponse {
+  StateChecksumHex: string;
+}

--- a/libs/deso-protocol-types/src/lib/deso-types.ts
+++ b/libs/deso-protocol-types/src/lib/deso-types.ts
@@ -4492,6 +4492,31 @@ export interface DAOCoinLimitOrderWithCancelOrderIDRequest {
   TransactionFees: TransactionFee[] | null;
 }
 
+export interface AssociationLimitMapItem {
+  AssociationClass: 'Post' | 'User' | 'Undefined';
+  AssociationType: string;
+  AppScopeType: 'Any' | 'Scoped' | 'Undefined';
+  AppPublicKeyBase58Check: string;
+  AssociationOperation: 'Any' | 'Create' | 'Delete' | 'Undefined';
+  OpCount: number;
+}
+
+export interface AccessGroupLimitMapItem {
+  AccessGroupOwnerPublicKeyBase58Check: string;
+  ScopeType: 'Any' | 'Scoped' | 'Undefined';
+  AccessGroupKeyName: string;
+  OperationType: 'Any' | 'Create' | 'Update' | 'Unknown';
+  OpCount: number;
+}
+
+export interface AccessGroupMemberLimitMapItem {
+  AccessGroupOwnerPublicKeyBase58Check: string;
+  ScopeType: 'Any' | 'Scoped' | 'Undefined';
+  AccessGroupKeyName: string;
+  OperationType: 'Any' | 'Add' | 'Remove' | 'Update' | 'Unknown';
+  OpCount: number;
+}
+
 // struct2ts:types/generated/types.TransactionSpendingLimitResponse
 export interface TransactionSpendingLimitResponse {
   GlobalDESOLimit?: number;
@@ -4502,6 +4527,9 @@ export interface TransactionSpendingLimitResponse {
     [key: string]: { [key: number]: { [key: string]: number } };
   };
   DAOCoinLimitOrderLimitMap?: { [key: string]: { [key: string]: number } };
+  AssociationLimitMap?: AssociationLimitMapItem[];
+  AccessGroupLimitMap?: AccessGroupLimitMapItem[];
+  AccessGroupMemberLimitMap?: AccessGroupMemberLimitMapItem[];
   IsUnlimited?: boolean;
 }
 
@@ -5295,4 +5323,108 @@ export interface GetSnapshotEpochMetadataResponse {
 
 export interface GetStateChecksumResponse {
   StateChecksumHex: string;
+}
+
+export interface AssociationQuery {
+  TransactorPublicKeyBase58Check: string;
+  AppPublicKeyBase58Check: string;
+  AssociationType: string;
+  AssociationTypePrefix: string;
+  AssociationValue: string;
+  AssociationValuePrefix: string;
+  AssociationValues: string[];
+  Limit: number;
+  LastSeenAssociationID: string;
+  SortDescending: boolean;
+  IncludeTransactorProfile: boolean;
+  IncludeAppProfile: boolean;
+}
+
+export interface UserAssociationQuery extends AssociationQuery {
+  TargetUserPublicKeyBase58Check: string;
+  IncludeTargetUserProfile: boolean;
+}
+
+export interface PostAssociationQuery extends AssociationQuery {
+  PostHashHex: string;
+  IncludePostEntry: boolean;
+  IncludePostAuthorProfile: boolean;
+}
+
+export interface CreateAssociationRequest {
+  TransactorPublicKeyBase58Check: string;
+  AppPublicKeyBase58Check: string;
+  AssociationType: string;
+  AssociationValue: string;
+  ExtraData: { [k: string]: string };
+  MinFeeRateNanosPerKB: number;
+  TransactionFees: TransactionFee[];
+}
+
+export interface CreateUserAssociationRequest extends CreateAssociationRequest {
+  TargetUserPublicKeyBase58Check: string;
+}
+
+export interface CreatePostAssociationRequest extends CreateAssociationRequest {
+  PostHashHex: string;
+}
+
+export interface AssociationResponse {
+  AssociationID: string;
+  TransactorPublicKeyBase58Check: string;
+  AppPublicKeyBase58Check: string;
+  AssociationType: string;
+  AssociationValue: string;
+  ExtraData: { [k: string]: string };
+  BlockHeight: number;
+  TransactorProfile: ProfileEntryResponse | null;
+  AppProfile: ProfileEntryResponse | null;
+}
+
+export interface UserAssociationResponse extends AssociationResponse {
+  TargetUserPublicKeyBase58Check: string;
+  TargetUserProfile: ProfileEntryResponse | null;
+}
+
+export interface PostAssociationResponse extends AssociationResponse {
+  PostHashHex: string;
+  PostEntry: PostEntryResponse | null;
+  PostAuthorProfile: ProfileEntryResponse | null;
+}
+
+export interface UserAssociationsResponse {
+  Associations: UserAssociationResponse[];
+  PublicKeyToProfileEntryResponse: PublicKeyToProfileEntryResponseMap;
+}
+
+export interface PostAssociationsResponse {
+  Associations: PostAssociationResponse[];
+  PublicKeyToProfileEntryResponse: PublicKeyToProfileEntryResponseMap;
+}
+
+export interface DeleteAssociationRequest {
+  TransactorPublicKeyBase58Check: string;
+  AssociationID: string;
+  ExtraData: { [k: string]: string };
+  MinFeeRateNanosPerKB: number;
+  TransactionFees: TransactionFee[];
+}
+
+export interface AssociationTxnResponse {
+  SpendAmountNanos: number;
+  TotalInputNanos: number;
+  ChangeAmountNanos: number;
+  FeeNames: number;
+  Transaction: MsgDeSoTxn;
+  TransactionHex: string;
+  TxnHashHex: string;
+}
+
+export interface AssociationsCountResponse {
+  Count: number;
+}
+
+export interface AssociationCountsResponse {
+  Counts: { [k: string]: number };
+  Total: number;
 }

--- a/libs/deso-protocol/src/index.ts
+++ b/libs/deso-protocol/src/index.ts
@@ -16,6 +16,8 @@ import { User } from './lib/user/User';
 import * as Utils from './lib/utils/Utils';
 import { Wallet } from './lib/wallet/Wallet';
 import { AccessGroup } from './lib/accessgroup/AccessGroup';
+import { Snapshot } from './lib/snapshot/Snapshot';
+import { Association } from './lib/association/Association';
 
 export { Ethereum as Metamask } from './lib/metamask/Ethereum';
 // export * as Utils from './lib/utils/Utils';
@@ -50,6 +52,8 @@ export class Deso {
     this.wallet = new Wallet(this.node, this.identity);
     this.referral = new Referral(this.node, this.identity);
     this.accessGroup = new AccessGroup(this.node, this.identity);
+    this.snapshot = new Snapshot(this.node);
+    this.association = new Association(this.node, this.identity);
     this.ethereum = new Ethereum(
       this.node,
       this.identity,
@@ -79,6 +83,8 @@ export class Deso {
   public referral: Referral;
   public ethereum: Ethereum;
   public accessGroup: AccessGroup;
+  public snapshot: Snapshot;
+  public association: Association;
   public utils = Utils;
 
   reinitialize(): void {
@@ -96,6 +102,8 @@ export class Deso {
     this.wallet = new Wallet(this.node, this.identity);
     this.referral = new Referral(this.node, this.identity);
     this.accessGroup = new AccessGroup(this.node, this.identity);
+    this.snapshot = new Snapshot(this.node);
+    this.association = new Association(this.node, this.identity);
     this.ethereum = new Ethereum(
       this.node,
       this.identity,

--- a/libs/deso-protocol/src/lib/accessgroup/AccessGroup.ts
+++ b/libs/deso-protocol/src/lib/accessgroup/AccessGroup.ts
@@ -1,15 +1,21 @@
 import axios from 'axios';
 import {
+  AccessGroupEntryResponse,
+  AccessGroupMemberEntryResponse,
   AddAccessGroupMembersRequest,
   AddAccessGroupMembersResponse,
   CheckPartyAccessGroupsRequest,
   CheckPartyAccessGroupsResponse,
   CreateAccessGroupRequest,
   CreateAccessGroupResponse,
+  GetAccessGroupInfoRequest,
+  GetAccessGroupMemberRequest,
   GetAccessGroupsRequest,
   GetAccessGroupsResponse,
   GetBulkAccessGroupEntriesRequest,
   GetBulkAccessGroupEntriesResponse,
+  GetPaginatedAccessGroupMembersRequest,
+  GetPaginatedAccessGroupMembersResponse,
   GetPaginatedMessagesForDmThreadRequest,
   GetPaginatedMessagesForDmThreadResponse,
   GetPaginatedMessagesForGroupChatThreadRequest,
@@ -19,9 +25,11 @@ import {
   RequestOptions,
   SendNewMessageRequest,
   SendNewMessageResponse,
-  SubmitTransactionResponse,
 } from 'deso-protocol-types';
-import { Identity } from '../identity/Identity';
+import {
+  DeSoProtocolSubmitTransactionResponse,
+  Identity,
+} from '../identity/Identity';
 import { Node } from '../Node/Node';
 
 export class AccessGroup {
@@ -35,7 +43,9 @@ export class AccessGroup {
   public async CreateAccessGroup(
     request: Partial<CreateAccessGroupRequest>,
     options?: RequestOptions
-  ): Promise<CreateAccessGroupResponse & SubmitTransactionResponse> {
+  ): Promise<
+    CreateAccessGroupResponse & DeSoProtocolSubmitTransactionResponse
+  > {
     // TODO: what needs to happen in identity
     const response: CreateAccessGroupResponse = (
       await axios.post(`${this.node.getUri()}/create-access-group`, request)
@@ -50,14 +60,82 @@ export class AccessGroup {
       });
   }
 
+  public async UpdateAccessGroup(
+    request: Partial<CreateAccessGroupRequest>,
+    options?: RequestOptions
+  ): Promise<
+    CreateAccessGroupResponse & DeSoProtocolSubmitTransactionResponse
+  > {
+    // TODO: what needs to happen in identity
+    const response: CreateAccessGroupResponse = (
+      await axios.post(`${this.node.getUri()}/update-access-group`, request)
+    ).data;
+    return await this.identity
+      .submitTransaction(response.TransactionHex, options)
+      .then((stRes) => {
+        return { ...response, ...stRes };
+      })
+      .catch(() => {
+        throw Error('something went wrong while signing');
+      });
+  }
+
   public async AddAccessGroupMembers(
     request: Partial<AddAccessGroupMembersRequest>,
     options?: RequestOptions
-  ): Promise<AddAccessGroupMembersResponse & SubmitTransactionResponse> {
+  ): Promise<
+    AddAccessGroupMembersResponse & DeSoProtocolSubmitTransactionResponse
+  > {
     // TODO: what needs to happen in identity
     const response: AddAccessGroupMembersResponse = (
       await axios.post(
         `${this.node.getUri()}/add-access-group-members`,
+        request
+      )
+    ).data;
+    return await this.identity
+      .submitTransaction(response.TransactionHex, options)
+      .then((stRes) => {
+        return { ...response, ...stRes };
+      })
+      .catch(() => {
+        throw Error('something went wrong while signing');
+      });
+  }
+
+  public async RemoveAccessGroupMembers(
+    request: Partial<AddAccessGroupMembersRequest>,
+    options?: RequestOptions
+  ): Promise<
+    AddAccessGroupMembersResponse & DeSoProtocolSubmitTransactionResponse
+  > {
+    // TODO: what needs to happen in identity
+    const response: AddAccessGroupMembersResponse = (
+      await axios.post(
+        `${this.node.getUri()}/remove-access-group-members`,
+        request
+      )
+    ).data;
+    return await this.identity
+      .submitTransaction(response.TransactionHex, options)
+      .then((stRes) => {
+        return { ...response, ...stRes };
+      })
+      .catch(() => {
+        throw Error('something went wrong while signing');
+      });
+  }
+
+  public async UpdateAccessGroupMembers(
+    request: Partial<AddAccessGroupMembersRequest>,
+    options?: RequestOptions
+  ): Promise<
+    AddAccessGroupMembersResponse & DeSoProtocolSubmitTransactionResponse
+  > {
+    // TODO: what needs to happen in identity
+    const response: AddAccessGroupMembersResponse = (
+      await axios.post(
+        `${this.node.getUri()}/update-access-group-members`,
         request
       )
     ).data;
@@ -115,6 +193,36 @@ export class AccessGroup {
     ).data;
   }
 
+  public async GetAccessGroupInfo(
+    request: GetAccessGroupInfoRequest
+  ): Promise<AccessGroupEntryResponse> {
+    return (
+      await axios.post(`${this.node.getUri()}/get-access-group-info`, request)
+    ).data;
+  }
+
+  public async GetAccessGroupMemberInfo(
+    request: GetAccessGroupMemberRequest
+  ): Promise<AccessGroupMemberEntryResponse> {
+    return (
+      await axios.post(
+        `${this.node.getUri()}/get-access-group-member-info`,
+        request
+      )
+    ).data;
+  }
+
+  public async GetPaginatedAccessGroupMembers(
+    request: Partial<GetPaginatedAccessGroupMembersRequest>
+  ): Promise<GetPaginatedAccessGroupMembersResponse> {
+    return (
+      await axios.post(
+        `${this.node.getUri()}/get-paginated-access-group-members`,
+        request
+      )
+    ).data;
+  }
+
   public async GetBulkAccessGroupEntries(
     request: Partial<GetBulkAccessGroupEntriesRequest>
   ): Promise<GetBulkAccessGroupEntriesResponse> {
@@ -129,7 +237,7 @@ export class AccessGroup {
   public async SendDmMessage(
     request: Partial<SendNewMessageRequest>,
     options?: RequestOptions
-  ): Promise<SendNewMessageResponse & SubmitTransactionResponse> {
+  ): Promise<SendNewMessageResponse & DeSoProtocolSubmitTransactionResponse> {
     // TODO: what needs to happen in identity
     const response: SendNewMessageResponse = (
       await axios.post(`${this.node.getUri()}/send-dm-message`, request)
@@ -145,13 +253,54 @@ export class AccessGroup {
       });
   }
 
+  public async UpdateDmMessage(
+    request: Partial<SendNewMessageRequest>,
+    options?: RequestOptions
+  ): Promise<SendNewMessageResponse & DeSoProtocolSubmitTransactionResponse> {
+    // TODO: what needs to happen in identity
+    const response: SendNewMessageResponse = (
+      await axios.post(`${this.node.getUri()}/update-dm-message`, request)
+    ).data;
+
+    return await this.identity
+      .submitTransaction(response.TransactionHex, options)
+      .then((stRes) => {
+        return { ...response, ...stRes };
+      })
+      .catch(() => {
+        throw Error('something went wrong while signing');
+      });
+  }
+
   public async SendGroupChatMessage(
     request: Partial<SendNewMessageRequest>,
     options?: RequestOptions
-  ): Promise<SendNewMessageResponse & SubmitTransactionResponse> {
+  ): Promise<SendNewMessageResponse & DeSoProtocolSubmitTransactionResponse> {
     // TODO: what needs to happen in identity
     const response: SendNewMessageResponse = (
       await axios.post(`${this.node.getUri()}/send-group-chat-message`, request)
+    ).data;
+
+    return await this.identity
+      .submitTransaction(response.TransactionHex, options)
+      .then((stRes) => {
+        return { ...response, ...stRes };
+      })
+      .catch(() => {
+        throw Error('something went wrong while signing');
+      });
+  }
+
+  public async UpdateGroupChatMessage(
+    request: Partial<SendNewMessageRequest>,
+    options?: RequestOptions
+  ): Promise<SendNewMessageResponse & DeSoProtocolSubmitTransactionResponse> {
+    // TODO: what needs to happen in identity
+    const response: SendNewMessageResponse = (
+      await axios.post(
+        `${this.node.getUri()}/update-group-chat-message`,
+        request
+      )
     ).data;
 
     return await this.identity

--- a/libs/deso-protocol/src/lib/association/Association.ts
+++ b/libs/deso-protocol/src/lib/association/Association.ts
@@ -1,0 +1,207 @@
+import axios from 'axios';
+import {
+  RequestOptions,
+  AssociationTxnResponse,
+  UserAssociationResponse,
+  PostAssociationResponse,
+  UserAssociationsResponse,
+  PostAssociationsResponse,
+  CreatePostAssociationRequest,
+  CreateUserAssociationRequest,
+  DeleteAssociationRequest,
+  UserAssociationQuery,
+  PostAssociationQuery,
+  AssociationCountsResponse,
+  AssociationsCountResponse,
+} from 'deso-protocol-types';
+import {
+  DeSoProtocolSubmitTransactionResponse,
+  Identity,
+} from '../identity/Identity';
+import { Node } from '../Node/Node';
+
+enum AssociationRoute {
+  POST = 'post-associations',
+  USER = 'user-associations',
+}
+
+export class Association {
+  private node: Node;
+  private identity: Identity;
+  constructor(node: Node, identity: Identity) {
+    this.node = node;
+    this.identity = identity;
+  }
+
+  private async executeAssociationTxn(
+    operation: 'create' | 'delete',
+    userOrPost: AssociationRoute,
+    requestBody: Partial<
+      | CreateUserAssociationRequest
+      | CreatePostAssociationRequest
+      | DeleteAssociationRequest
+    >,
+    options?: RequestOptions
+  ): Promise<AssociationTxnResponse & DeSoProtocolSubmitTransactionResponse> {
+    const response: AssociationTxnResponse = (
+      await axios.post(
+        `${this.node.getUri()}/${userOrPost}-associations/${operation}`,
+        requestBody
+      )
+    ).data;
+
+    return await this.identity
+      .submitTransaction(response.TransactionHex, options)
+      .then((stRes) => ({ ...response, ...stRes }))
+      .catch(() => {
+        throw Error('something went wrong while signing');
+      });
+  }
+
+  public async CreateUserAssociation(
+    request: Partial<CreateUserAssociationRequest>,
+    options?: RequestOptions
+  ): Promise<AssociationTxnResponse & DeSoProtocolSubmitTransactionResponse> {
+    return this.executeAssociationTxn(
+      'create',
+      AssociationRoute.USER,
+      request,
+      options
+    );
+  }
+
+  public async CreatePostAssociation(
+    request: Partial<CreatePostAssociationRequest>,
+    options?: RequestOptions
+  ): Promise<AssociationTxnResponse & DeSoProtocolSubmitTransactionResponse> {
+    return this.executeAssociationTxn(
+      'create',
+      AssociationRoute.POST,
+      request,
+      options
+    );
+  }
+
+  public async DeleteUserAssociation(
+    request: Partial<DeleteAssociationRequest>,
+    options?: RequestOptions
+  ): Promise<AssociationTxnResponse & DeSoProtocolSubmitTransactionResponse> {
+    return this.executeAssociationTxn(
+      'delete',
+      AssociationRoute.USER,
+      request,
+      options
+    );
+  }
+
+  public async DeletePostAssociation(
+    request: Partial<DeleteAssociationRequest>,
+    options?: RequestOptions
+  ): Promise<AssociationTxnResponse & DeSoProtocolSubmitTransactionResponse> {
+    return this.executeAssociationTxn(
+      'delete',
+      AssociationRoute.POST,
+      request,
+      options
+    );
+  }
+
+  public async GetUserAssociationByID(
+    AssociationID: string
+  ): Promise<UserAssociationResponse> {
+    return (
+      await axios.get(
+        `${this.node.getUri()}/${AssociationRoute.USER}/${AssociationID}`
+      )
+    ).data;
+  }
+
+  public async GetPostAssociationByID(
+    AssociationID: string
+  ): Promise<PostAssociationResponse> {
+    return (
+      await axios.get(
+        `${this.node.getUri()}/${AssociationRoute.POST}/${AssociationID}`
+      )
+    ).data;
+  }
+
+  private async executeAssociationQuery<
+    T extends
+      | UserAssociationsResponse
+      | PostAssociationsResponse
+      | AssociationsCountResponse
+      | AssociationCountsResponse
+  >(
+    request: Partial<UserAssociationQuery | PostAssociationQuery>,
+    operation: 'query' | 'count' | 'counts',
+    associationRoute: AssociationRoute
+  ): Promise<T> {
+    return (
+      await axios.post(
+        `${this.node.getUri()}/${associationRoute}/${operation}`,
+        request
+      )
+    ).data;
+  }
+
+  public async GetUserAssociations(
+    request: Partial<UserAssociationQuery>
+  ): Promise<UserAssociationsResponse> {
+    return this.executeAssociationQuery<UserAssociationsResponse>(
+      request,
+      'query',
+      AssociationRoute.USER
+    );
+  }
+
+  public async GetPostAssociations(
+    request: Partial<PostAssociationQuery>
+  ): Promise<PostAssociationsResponse> {
+    return this.executeAssociationQuery<PostAssociationsResponse>(
+      request,
+      'query',
+      AssociationRoute.POST
+    );
+  }
+
+  public async CountUserAssociations(
+    request: Partial<UserAssociationQuery>
+  ): Promise<AssociationsCountResponse> {
+    return this.executeAssociationQuery<AssociationsCountResponse>(
+      request,
+      'count',
+      AssociationRoute.USER
+    );
+  }
+
+  public async CountPostAssociations(
+    request: Partial<PostAssociationQuery>
+  ): Promise<AssociationsCountResponse> {
+    return this.executeAssociationQuery<AssociationsCountResponse>(
+      request,
+      'count',
+      AssociationRoute.POST
+    );
+  }
+
+  public async CountUserAssociationsByValues(
+    request: Partial<UserAssociationQuery>
+  ): Promise<AssociationCountsResponse> {
+    return this.executeAssociationQuery<AssociationCountsResponse>(
+      request,
+      'counts',
+      AssociationRoute.USER
+    );
+  }
+
+  public async CountPostAssociationsByValues(
+    request: Partial<PostAssociationQuery>
+  ): Promise<AssociationCountsResponse> {
+    return this.executeAssociationQuery<AssociationCountsResponse>(
+      request,
+      'counts',
+      AssociationRoute.POST
+    );
+  }
+}

--- a/libs/deso-protocol/src/lib/dao/dao.ts
+++ b/libs/deso-protocol/src/lib/dao/dao.ts
@@ -14,7 +14,10 @@ import {
   TransferDAOCoinRequest,
   TransferDAOCoinResponse,
 } from 'deso-protocol-types';
-import { Identity } from '../identity/Identity';
+import {
+  DeSoProtocolSubmitTransactionResponse,
+  Identity,
+} from '../identity/Identity';
 import { Node } from '../Node/Node';
 
 export class DAO {
@@ -33,14 +36,17 @@ export class DAO {
     request: Partial<REQUEST>,
     endpoint: string,
     options?: RequestOptions
-  ): Promise<RESPONSE> {
+  ): Promise<RESPONSE & DeSoProtocolSubmitTransactionResponse> {
     request = { ...{ MinFeeRateNanosPerKB: 1000 }, ...request };
     const response = (
       await axios.post<RESPONSE>(`${this.node.getUri()}/${endpoint}`, request)
     ).data;
     return await this.identity
       .submitTransaction(response.TransactionHex, options)
-      .then(() => response);
+      .then((submitTransactionResponse) => ({
+        ...response,
+        ...submitTransactionResponse,
+      }));
   }
 
   private async executePost<REQUEST, RESPONSE>(

--- a/libs/deso-protocol/src/lib/media/Media.ts
+++ b/libs/deso-protocol/src/lib/media/Media.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 import {
+  EnableVideoDownloadResponse,
   GetFullTikTokURLRequest,
   GetFullTikTokURLResponse,
+  GetVideoDimensionsResponse,
   GetVideoStatusRequest,
   GetVideoStatusResponse,
   UploadImageRequest,
@@ -69,5 +71,21 @@ export class Media {
     const endpoint = 'get-full-tiktok-url';
     return (await axios.post(`${this.node.getUri()}/${endpoint}`, request))
       .data;
+  }
+
+  public async EnableVideoDownload(
+    videoId: string
+  ): Promise<EnableVideoDownloadResponse> {
+    return (
+      await axios.post(`${this.node.getUri()}/enable-video-download/${videoId}`)
+    ).data;
+  }
+
+  public async GetVideoDimensions(
+    videoId: string
+  ): Promise<GetVideoDimensionsResponse> {
+    return (
+      await axios.post(`${this.node.getUri()}/get-video-dimensions/${videoId}`)
+    ).data;
   }
 }

--- a/libs/deso-protocol/src/lib/nft/Nft.ts
+++ b/libs/deso-protocol/src/lib/nft/Nft.ts
@@ -3,6 +3,7 @@ import {
   AcceptNFTBidRequest,
   AcceptNFTBidResponse,
   AcceptNFTTransferRequest,
+  AcceptNFTTransferResponse,
   BurnNFTRequest,
   BurnNFTResponse,
   CreateNFTBidRequest,
@@ -28,7 +29,10 @@ import {
   UpdateNFTRequest,
   UpdateNFTResponse,
 } from 'deso-protocol-types';
-import { Identity } from '../identity/Identity';
+import {
+  DeSoProtocolSubmitTransactionResponse,
+  Identity,
+} from '../identity/Identity';
 import { Node } from '../Node/Node';
 
 export class Nft {
@@ -98,14 +102,14 @@ export class Nft {
   public async createNft(
     request: Partial<CreateNFTRequest>,
     options?: RequestOptions
-  ): Promise<CreateNFTResponse> {
+  ): Promise<CreateNFTResponse & DeSoProtocolSubmitTransactionResponse> {
     const endpoint = 'create-nft';
     const apiResponse: CreateNFTResponse = (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
-    ).data;
+    ).data as CreateNFTResponse;
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });
@@ -114,15 +118,15 @@ export class Nft {
   public async updateNft(
     request: Partial<UpdateNFTRequest>,
     options?: RequestOptions
-  ): Promise<UpdateNFTResponse> {
+  ): Promise<UpdateNFTResponse & DeSoProtocolSubmitTransactionResponse> {
     const endpoint = 'update-nft';
     const apiResponse = (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
-    ).data;
+    ).data as UpdateNFTResponse;
 
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });
@@ -131,17 +135,15 @@ export class Nft {
   public async createNftBid(
     request: Partial<CreateNFTBidRequest>,
     options?: RequestOptions
-  ): Promise<CreateNFTBidResponse> {
+  ): Promise<CreateNFTBidResponse & DeSoProtocolSubmitTransactionResponse> {
     const endpoint = 'create-nft-bid';
     const apiResponse = (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
-    ).data;
+    ).data as CreateNFTBidResponse;
 
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => {
-        return apiResponse;
-      })
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });
@@ -150,14 +152,14 @@ export class Nft {
   public async acceptNftBid(
     request: Partial<AcceptNFTBidRequest>,
     options?: RequestOptions
-  ): Promise<AcceptNFTBidResponse> {
+  ): Promise<AcceptNFTBidResponse & DeSoProtocolSubmitTransactionResponse> {
     const endpoint = 'accept-nft-bid';
-    const apiResponse = await (
+    const apiResponse = (await (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
-    ).data;
+    ).data) as AcceptNFTBidResponse;
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });
@@ -166,14 +168,14 @@ export class Nft {
   public async transferNft(
     request: Partial<TransferNFTRequest>,
     options?: RequestOptions
-  ): Promise<TransferNFTResponse> {
+  ): Promise<TransferNFTResponse & DeSoProtocolSubmitTransactionResponse> {
     const endpoint = 'transfer-nft';
-    const apiResponse = await (
+    const apiResponse = (await (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
-    ).data;
+    ).data) as TransferNFTResponse;
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });
@@ -182,15 +184,17 @@ export class Nft {
   public async acceptNftTransfer(
     request: Partial<AcceptNFTTransferRequest>,
     options?: RequestOptions
-  ): Promise<TransferNFTResponse> {
+  ): Promise<
+    AcceptNFTTransferResponse & DeSoProtocolSubmitTransactionResponse
+  > {
     const endpoint = 'accept-nft-transfer';
     const apiResponse = (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
-    ).data;
+    ).data as AcceptNFTTransferResponse;
 
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });
@@ -198,14 +202,14 @@ export class Nft {
   public async burnNft(
     request: Partial<BurnNFTRequest>,
     options?: RequestOptions
-  ): Promise<BurnNFTResponse> {
+  ): Promise<BurnNFTResponse & DeSoProtocolSubmitTransactionResponse> {
     const endpoint = 'burn-nft';
     const apiResponse = (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
-    ).data;
+    ).data as BurnNFTResponse;
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });

--- a/libs/deso-protocol/src/lib/post/Posts.ts
+++ b/libs/deso-protocol/src/lib/post/Posts.ts
@@ -9,6 +9,8 @@ import {
   GetPostsDiamondedBySenderForReceiverResponse,
   GetPostsForPublicKeyRequest,
   GetPostsForPublicKeyResponse,
+  GetPostsHashHexListRequest,
+  GetPostsHashHexListResponse,
   GetPostsStatelessRequest,
   GetPostsStatelessResponse,
   GetQuoteRepostsForPostRequest,
@@ -21,6 +23,7 @@ import {
   RequestOptions,
   SubmitPostRequest,
   SubmitPostResponse,
+  SubmitTransactionResponse,
 } from 'deso-protocol-types';
 import { throwErrors } from '../../utils/Utils';
 import { Identity } from '../identity/Identity';
@@ -52,7 +55,9 @@ export class Posts {
     extraData?: Omit<AppendExtraDataRequest, 'TransactionHex'>
   ): Promise<{
     constructedTransactionResponse: SubmitPostResponse;
-    submittedTransactionResponse: any;
+    submittedTransactionResponse:
+      | { TransactionHex: string }
+      | SubmitTransactionResponse;
   }> {
     if (!request.UpdaterPublicKeyBase58Check) {
       throw Error('UpdaterPublicKeyBase58Check is required');
@@ -76,7 +81,8 @@ export class Posts {
       .then((submittedTransactionResponse) => {
         return {
           constructedTransactionResponse,
-          submittedTransactionResponse,
+          submittedTransactionResponse:
+            submittedTransactionResponse.SubmitTransactionResponse,
         };
       })
       .catch((e: Error) => {
@@ -90,6 +96,14 @@ export class Posts {
     const endpoint = 'get-posts-stateless';
     return await (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
+    ).data;
+  }
+
+  public async getPostsHashHexList(
+    request: Partial<GetPostsHashHexListRequest>
+  ): Promise<GetPostsHashHexListResponse> {
+    return (
+      await axios.post(`${this.node.getUri()}/get-posts-hashhexlist`, request)
     ).data;
   }
 

--- a/libs/deso-protocol/src/lib/snapshot/Snapshot.ts
+++ b/libs/deso-protocol/src/lib/snapshot/Snapshot.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import {
+  GetSnapshotEpochMetadataResponse,
+  GetStateChecksumResponse,
+} from 'deso-protocol-types';
+import { Node } from '../Node/Node';
+
+export class Snapshot {
+  private node: Node;
+  constructor(node: Node) {
+    this.node = node;
+  }
+
+  public async GetSnapshotEpochMetadata(): Promise<GetSnapshotEpochMetadataResponse> {
+    return (await axios.get(`${this.node.getUri()}/snapshot-epoch-metadata`))
+      .data;
+  }
+
+  public async GetStateChecksum(): Promise<GetStateChecksumResponse> {
+    return (await axios.get(`${this.node.getUri()}/state-checksum`)).data;
+  }
+}

--- a/libs/deso-protocol/src/lib/user/User.ts
+++ b/libs/deso-protocol/src/lib/user/User.ts
@@ -24,9 +24,13 @@ import {
   GetUserGlobalMetadataResponse,
   UpdateUserGlobalMetadataRequest,
   RequestOptions,
+  DerivedPrivateUserInfo,
 } from 'deso-protocol-types';
 import { throwErrors } from '../../utils/Utils';
-import { Identity } from '../identity/Identity';
+import {
+  DeSoProtocolSubmitTransactionResponse,
+  Identity,
+} from '../identity/Identity';
 import { Node } from '../Node/Node';
 export class User {
   private node: Node;
@@ -192,7 +196,12 @@ export class User {
   public async authorizeDerivedKey(
     request: Partial<AuthorizeDerivedKeyParams>,
     options?: RequestOptions
-  ): Promise<AuthorizeDerivedKeyResponse> {
+  ): Promise<
+    AuthorizeDerivedKeyResponse &
+      DeSoProtocolSubmitTransactionResponse & {
+        DerivedPrivateUserInfo: DerivedPrivateUserInfo;
+      }
+  > {
     throwErrors(['MinFeeRateNanosPerKB'], request);
     const derivedPrivateUser = await this.identity.derive({
       publicKey: this.identity.getUserKey() || undefined,
@@ -227,7 +236,7 @@ export class User {
 
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });

--- a/libs/deso-protocol/src/lib/user/User.ts
+++ b/libs/deso-protocol/src/lib/user/User.ts
@@ -199,7 +199,7 @@ export class User {
   ): Promise<
     AuthorizeDerivedKeyResponse &
       DeSoProtocolSubmitTransactionResponse & {
-        DerivedPrivateUserInfo: DerivedPrivateUserInfo;
+        DerivedPrivateUser: DerivedPrivateUserInfo;
       }
   > {
     throwErrors(['MinFeeRateNanosPerKB'], request);
@@ -236,7 +236,11 @@ export class User {
 
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then((stRes) => ({ ...apiResponse, ...stRes }))
+      .then((stRes) => ({
+        ...apiResponse,
+        ...stRes,
+        ...{ DerivedPrivateUser: derivedPrivateUser },
+      }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });

--- a/libs/deso-protocol/src/lib/wallet/Wallet.ts
+++ b/libs/deso-protocol/src/lib/wallet/Wallet.ts
@@ -1,12 +1,17 @@
 import axios from 'axios';
 import {
+  BuyOrSellCreatorCoinRequest,
+  BuyOrSellCreatorCoinResponse,
   RequestOptions,
   SendDeSoRequest,
   SendDeSoResponse,
   TransferCreatorCoinRequest,
   TransferCreatorCoinResponse,
 } from 'deso-protocol-types';
-import { Identity } from '../identity/Identity';
+import {
+  DeSoProtocolSubmitTransactionResponse,
+  Identity,
+} from '../identity/Identity';
 
 import { Node } from '../Node/Node';
 
@@ -21,30 +26,32 @@ export class Wallet {
   public async sendDesoRequest(
     request: Partial<SendDeSoRequest>,
     options?: RequestOptions
-  ): Promise<SendDeSoResponse> {
+  ): Promise<SendDeSoResponse & DeSoProtocolSubmitTransactionResponse> {
     const endpoint = 'send-deso';
-    const apiResponse = (
+    const apiResponse: SendDeSoResponse = (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
     ).data;
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });
   }
 
   public async buyOrSellCreatorCoin(
-    request: Partial<SendDeSoRequest>,
+    request: Partial<BuyOrSellCreatorCoinRequest>,
     options?: RequestOptions
-  ): Promise<SendDeSoResponse> {
+  ): Promise<
+    BuyOrSellCreatorCoinResponse & DeSoProtocolSubmitTransactionResponse
+  > {
     const endpoint = 'buy-or-sell-creator-coin';
-    const apiResponse = (
+    const apiResponse: BuyOrSellCreatorCoinResponse = (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
     ).data;
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });
@@ -53,14 +60,16 @@ export class Wallet {
   public async transferCreatorCoin(
     request: Partial<TransferCreatorCoinRequest>,
     options?: RequestOptions
-  ): Promise<TransferCreatorCoinResponse> {
+  ): Promise<
+    TransferCreatorCoinResponse & DeSoProtocolSubmitTransactionResponse
+  > {
     const endpoint = 'transfer-creator-coin';
-    const apiResponse = (
+    const apiResponse: TransferCreatorCoinResponse = (
       await axios.post(`${this.node.getUri()}/${endpoint}`, request)
     ).data;
     return await this.identity
       .submitTransaction(apiResponse.TransactionHex, options)
-      .then(() => apiResponse)
+      .then((stRes) => ({ ...apiResponse, ...stRes }))
       .catch(() => {
         throw Error('something went wrong while signing');
       });


### PR DESCRIPTION
add snapshot endpoints and types, add new media endpoints and types, add OnlyNFTs and OnlyPosts to get posts request types, add GetPostHashHexList endpoint, add/update access group and new message endpoints and types, always return the response from SubmitTransaction calls when using endpoints that construct + sign + submit transactions